### PR TITLE
Added ip_address to reactions in DatabaseSeeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -91,6 +91,7 @@ class DatabaseSeeder extends Seeder
                         'type' => fake()->randomElement(array_keys(config('comments.reactions'))),
                         'owner_id' => $guest->getKey(),
                         'owner_type' => $guest->getMorphClass(),
+                        'ip_address' => $guest->ip_address,
                     ];
                 }
 
@@ -145,7 +146,8 @@ class DatabaseSeeder extends Seeder
                     $reactions[] = [
                         'type' => fake()->randomElement(array_keys(config('comments.reactions'))),
                         'owner_id' => User::factory()->create()->getAuthIdentifier(),
-                        'owner_type' => (new User())->getMorphClass()
+                        'owner_type' => (new User())->getMorphClass(),
+                        'ip_address' => fake()->ipv4(),
                     ];
                 }
 


### PR DESCRIPTION
**Issue**:  
While seeding the database, I encountered the following error:  

```
SQLSTATE[HY000]: General error: 1364 Field 'ip_address' doesn't have a default value
```

This occurred because the `ip_address` field in the `reactions` table is non-nullable and lacks a default value. 

**Solution**:  
I updated the database seeder to include fake `ip_address` values when creating reactions, ensuring the `ip_address` field is populated during seeding.